### PR TITLE
possible solution

### DIFF
--- a/WorkSmarter/background.js
+++ b/WorkSmarter/background.js
@@ -5,57 +5,79 @@ let ifTimerOver = false;
 let urlStorage = [];
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-
-  if (request.cmd === 'STOP_TIMER') {
+  if (request.cmd === "STOP_TIMER") {
     stopTimer();
     sendResponse({ time: currentTime, timerOver: ifTimerOver });
     resetTime();
-    console.log('background.js - stop timer');
-
-  } else if (request.cmd === 'START_TIMER') {
+    console.log("background.js - stop timer");
+  } else if (request.cmd === "START_TIMER") {
     currentTime = request.when;
     startingMins = request.strarting;
     //storeCurrrentTime();
     storeStartingMins();
     startTimer();
-    console.log('background.js - timer started');
-
-  } else if (request.cmd === 'GET_TIME') {
-    sendResponse({ time: currentTime, timerOver: ifTimerOver, startedMinutes: startingMins });
-    console.log('background.js - sending current time');
-
-  } else if (request.cmd === 'RESET_TIME') {
+    console.log("background.js - timer started");
+  } else if (request.cmd === "GET_TIME") {
+    sendResponse({
+      time: currentTime,
+      timerOver: ifTimerOver,
+      startedMinutes: startingMins,
+    });
+    console.log("background.js - sending current time");
+  } else if (request.cmd === "RESET_TIME") {
     clearInterval(counter);
     resetTime();
-
-  } else if (request.cmd === 'STORE_URL') {
+  } else if (request.cmd === "STORE_URL") {
     let tempURL = new URL(request.link);
     storeURL(tempURL);
-
-  } else if (request.cmd === 'GET_DATA') {
+  } else if (request.cmd === "GET_DATA") {
     sendResponse({ link: urlStorage });
-
-  } else if (request.cmd === 'CLEAR_URLs') {
+  } else if (request.cmd === "CLEAR_URLs") {
     urlStorage = [];
   }
 });
 
+const blockedDomains = [
+  "www.bbc.co.uk",
+  "www.google.com",
+  "www.facebook.com",
+  "www.twitter.com",
+];
+
+function attemptInject(tab, tabId) {
+  let testURL = new URL(tab.url);
+  // if url is in the blocked domains list
+  console.log(blockedDomains, testURL.hostname);
+  if (blockedDomains.includes(testURL.hostname)) {
+    console.log("execute content script");
+    chrome.scripting.executeScript({
+      files: ["contentscript.js"],
+      target: { tabId: tabId },
+    });
+  } else {
+    console.log("blocked domain");
+  }
+}
+
 // call this when URL of current tab is changed to see if contentscript.js needs to be injected or not
 try {
-  chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+  chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+    console.log(changeInfo, tab);
     if (changeInfo.status == "complete") {
-      let testURL = new URL(tab.url);
-      if (!testURL.origin.includes('chrome') && !tab.url.includes('google')) {
-        if (changeInfo.status == 'complete') {
-          chrome.scripting.executeScript({
-            files: ['contentscript.js'],
-            target: {tabId: tab.id}
-          });
-          console.log(testURL.hostname);
-        }
-      } else {
-        console.log('Invalid URL onUpdated');
-      } 
+      // let testURL = new URL(tab.url);
+      // if url is in the blocked domains list
+      attemptInject(tab, tabId);
+      // if (!testURL.origin.includes('chrome') && !tab.url.includes('google')) {
+      //   if (changeInfo.status == 'complete') {
+      //     chrome.scripting.executeScript({
+      //       files: ['contentscript.js'],
+      //       target: {tabId: tab.id}
+      //     });
+      //     console.log(testURL.hostname);
+      //   }
+      // } else {
+      //   console.log('Invalid URL onUpdated');
+      // }
     }
   });
 } catch (e) {
@@ -64,38 +86,37 @@ try {
 
 // call this when the User changes tab and get the URL to see if contentscript.js needs to be injected or not
 try {
-  chrome.tabs.onActivated.addListener(function(activeInfo) {
+  chrome.tabs.onActivated.addListener(function (activeInfo) {
     getCurrentTab();
   });
 } catch (e) {
-  console.log('ERROR HAPPENED');
+  console.log("ERROR HAPPENED");
   console.log(e);
 }
 
-
-
 ///////////////   FUNCTIONS    /////////////////////////
 function getCurrentTab() {
-  chrome.tabs.query({active: true, lastFocusedWindow: true}, tabs => {
+  chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
     let url = tabs[0].url;
     let tab_Id = tabs[0].id;
     try {
-      let urlConstr = new URL(url);
-      console.log(!urlConstr.origin.includes('chrome'));
-      console.log(!url.includes('google'));
-      if (!urlConstr.origin.includes('chrome') && !url.includes('google')) {
-        console.log('execute content script');
-        console.log(urlConstr.hostname);
-        chrome.scripting.executeScript({
-          files: ['contentscript.js'],
-          target: {tabId: tab_Id}
-        });
-        console.log('changed content here');
-      } else {
-        console.log('chrome:// or google.com, do nothing');
-      }
-    } catch(e) {
-      console.log('ERROR HAPPENED - ' + e);
+      attemptInject(tabs[0], tab_Id);
+      // let urlConstr = new URL(url);
+      // console.log(!urlConstr.origin.includes("chrome"));
+      // console.log(!url.includes("google"));
+      // if (!urlConstr.origin.includes("chrome") && !url.includes("google")) {
+      //   console.log("execute content script");
+      //   console.log(urlConstr.hostname);
+      //   chrome.scripting.executeScript({
+      //     files: ["contentscript.js"],
+      //     target: { tabId: tab_Id },
+      //   });
+      //   console.log("changed content here");
+      // } else {
+      //   console.log("chrome:// or google.com, do nothing");
+      // }
+    } catch (e) {
+      console.log("ERROR HAPPENED - " + e);
     }
   });
 }
@@ -128,7 +149,7 @@ function UpdateCountDown() {
   const mins = Math.floor(currentTime / 60);
   let secs = currentTime % 60;
   console.log(`TotalSeconds - ${currentTime}`);
-  if (mins == 0 & secs == 0) {
+  if ((mins == 0) & (secs == 0)) {
     clearInterval(counter);
     ifTimerOver = true;
   }
@@ -144,38 +165,38 @@ function storeURL(userURL) {
   }
   if (!check) {
     urlStorage.push(userURL.hostname);
-    console.log('added url');
+    console.log("added url");
   }
 }
 
 function storeCurrrentTime() {
-  chrome.storage.sync.set({ 'localTime': currentTime }, function() {
-    console.log('storeCurrentTime - ' + currentTime);
-  })
+  chrome.storage.sync.set({ localTime: currentTime }, function () {
+    console.log("storeCurrentTime - " + currentTime);
+  });
 }
 
 function getCurrentTime() {
-  chrome.storage.sync.get(['localTime'], function(data) {
+  chrome.storage.sync.get(["localTime"], function (data) {
     currentTime = data.localTime;
-    console.log('getCurrentTime - ' + data.localTime);
-  })
+    console.log("getCurrentTime - " + data.localTime);
+  });
 }
 
 function storeStartingMins() {
-  chrome.storage.sync.set({ 'localStartingMins': startingMins }, function() {
-    console.log('storeStartingMins - ' + startingMins);
-  })
+  chrome.storage.sync.set({ localStartingMins: startingMins }, function () {
+    console.log("storeStartingMins - " + startingMins);
+  });
 }
 
 function getStartingMins() {
-  chrome.storage.sync.get(['localStartingMins'], function(data) {
+  chrome.storage.sync.get(["localStartingMins"], function (data) {
     startingMins = data.localStartingMins;
-    console.log('getStartingMins - ' + data.localStartingMins);
+    console.log("getStartingMins - " + data.localStartingMins);
   });
 }
 
 function clearLocalStorage() {
-  chrome.storage.local.clear(function() {
+  chrome.storage.local.clear(function () {
     let error = chrome.runtime.lastError;
     if (error) {
       console.error(error);

--- a/WorkSmarter/contentscript.css
+++ b/WorkSmarter/contentscript.css
@@ -1,5 +1,11 @@
 .test-element {
-    border: 3px solid blue;
-    height: 100px;
-    width: 100%;
+  all: initial;
+  border: 3px solid blue;
+  height: 100px;
+  width: 100%;
+  z-index: 999999999;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: white;
 }

--- a/WorkSmarter/contentscript.js
+++ b/WorkSmarter/contentscript.js
@@ -1,10 +1,27 @@
-if (typeof init === 'undefined') {
-    const init = function() {
-        const injectElement = document.createElement('div');
-        injectElement.className = 'test-element';
-        injectElement.innerHTML = 'THIS IS A TEST!!!!';
-        document.body.appendChild(injectElement);
-        console.log('Changed Content On This Page');
-    }
+var elementExist = document.querySelectorAll(
+  "#long-unique-random-id-for-extension"
+);
+if (elementExist.length !== 0) {
+  console.log("elementExits - stop");
+} else {
+  if (typeof init === "undefined") {
+    const init = function () {
+      // create and append css file
+      const css = document.createElement("link");
+      css.setAttribute("rel", "stylesheet");
+      css.setAttribute("type", "text/css");
+      css.setAttribute("href", chrome.runtime.getURL("contentscript.css"));
+      document.head.appendChild(css);
+      // create and append js file
+      const injectElement = document.createElement("div");
+      injectElement.className = "test-element";
+      injectElement.id = "long-unique-random-id-for-extension";
+      injectElement.innerHTML = "THIS IS A TEST!!!!";
+      document.body.appendChild(injectElement);
+      console.log("Changed Content On This Page");
+    };
     init();
+  } else {
+    console.log("Content Already Changed");
+  }
 }

--- a/WorkSmarter/manifest.json
+++ b/WorkSmarter/manifest.json
@@ -7,15 +7,6 @@
     "service_worker": "background.js"
   },
   "permissions": ["storage", "activeTab", "scripting", "tabs"],
-  "content_scripts": [
-    {
-      "all_frames" : false,
-      "matches": ["http://*/", "https://*/*"],
-      "js": ["contentscript.js"],
-      "css": ["contentscript.css"],
-      "run_at": "document_end"
-    }
-  ],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -31,6 +22,11 @@
     "48": "/images/48x48.png",
     "128": "/images/128x128.png"
   },
-  "host_permissions": ["http://*/", "https://*/*"],
-  "options_page": "options.html"
+  "web_accessible_resources": [
+    {
+      "resources": ["contentscript.css"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "host_permissions": ["http://*/", "https://*/*"]
 }


### PR DESCRIPTION
main changes are in the content script and background service worker. (ignore the indentation changes)

- manifest no longer inject the script, added web accessible resources to inject the css via the content script itself
- content script now also checks to see if an element with our id already exists (could event remove the other check)
- background script looks to see if the hostname matches a list of blocked domains before injecting. via a attemptInject function we can reuse for tab change / activated, could also add a check inside here for the timer status...